### PR TITLE
fmt.Errorf -> errors.New

### DIFF
--- a/response_writer.go
+++ b/response_writer.go
@@ -2,7 +2,7 @@ package martini
 
 import (
 	"bufio"
-	"fmt"
+	"errors"
 	"net"
 	"net/http"
 )
@@ -74,7 +74,7 @@ func (rw *responseWriter) Before(before BeforeFunc) {
 func (rw *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	hijacker, ok := rw.ResponseWriter.(http.Hijacker)
 	if !ok {
-		return nil, nil, fmt.Errorf("the ResponseWriter doesn't support the Hijacker interface")
+		return nil, nil, errors.New("the ResponseWriter doesn't support the Hijacker interface")
 	}
 	return hijacker.Hijack()
 }


### PR DESCRIPTION
fmt.Errorf is just an errors.New wrapped around fmt.Sprintf. As there was no formatting being done anyways, this was wasting cycles.  
```
BenchmarkErrorsNew-4       30000000          34 ns/op      16 B/op    1 allocs/op
BenchmarkFmtErrorF-4       10000000         123 ns/op      20 B/op    2 allocs/op
```